### PR TITLE
fix: removes duplicate entity ids during setup

### DIFF
--- a/custom_components/phoniebox/sensor.py
+++ b/custom_components/phoniebox/sensor.py
@@ -83,7 +83,6 @@ def discover_sensors(topic, payload, entry, coordinator):
         return GenericPhonieboxSensor(entry, coordinator, domain, unit)
 
 
-
 async def async_setup_entry(hass, entry, async_add_devices):
     """Setup sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
@@ -107,6 +106,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 async_add_devices((sensor,), True)
             else:
                 store[sensor.name].set_event(msg.payload)
+                store[sensor.name].async_schedule_update_ha_state()
 
     await coordinator.mqtt_client.async_subscribe("#", received_msg)
 
@@ -146,4 +146,3 @@ class GenericPhonieboxSensor(PhonieboxEntity, SensorEntity):
         if self.extract_value is not None:
             value = self.extract_value(event)
         self._attr_native_value = value
-        self.async_write_ha_state()

--- a/custom_components/phoniebox/switch.py
+++ b/custom_components/phoniebox/switch.py
@@ -67,13 +67,10 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 sensor.hass = hass
                 sensor.set_state(string_to_bool(msg.payload))
                 store[sensor.name] = sensor
-                LOGGER.debug(
-                    "Registering switch %(name)s",
-                    {"name": sensor.name},
-                )
                 async_add_devices((sensor,), True)
             else:
                 store[sensor.name].set_state(string_to_bool(msg.payload))
+                store[sensor.name].async_schedule_update_ha_state()
 
     await coordinator.mqtt_client.async_subscribe("#", received_msg)
 
@@ -110,7 +107,6 @@ class PhonieboxBinarySwitch(PhonieboxEntity, SwitchEntity, ABC):
     def set_state(self, value: bool) -> None:
         """Update the binary sensor with the most recent value."""
         self._attr_is_on = value
-        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -118,6 +114,7 @@ class PhonieboxBinarySwitch(PhonieboxEntity, SwitchEntity, ABC):
             f"cmd/{self._mqtt_topic}", self._mqtt_on_payload
         )
         self.set_state(True)
+        self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -125,3 +122,4 @@ class PhonieboxBinarySwitch(PhonieboxEntity, SwitchEntity, ABC):
             f"cmd/{self._mqtt_topic}", self._mqtt_off_payload
         )
         self.set_state(False)
+        self.async_schedule_update_ha_state()

--- a/test/test_binary_sensor.py
+++ b/test/test_binary_sensor.py
@@ -25,7 +25,7 @@ async def test_sensor_registry(
     )  # now added the sensor and for binary most-likely a switch as well
 
     entry: RegistryEntry = entity_registry.async_get(
-        "binary_sensor.phoniebox_test_box_gpio_2"
+        "binary_sensor.phoniebox_test_box_gpio"
     )
     assert entry
     assert entry.unique_id == "test_box-binary_sensor.phoniebox_test_box_gpio"
@@ -44,6 +44,6 @@ async def test_sensor_registry_update(
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/gpio", "false")
     await hass.async_block_till_done()
 
-    version_sensor_state = hass.states.get("binary_sensor.phoniebox_test_box_gpio_2")
+    version_sensor_state = hass.states.get("binary_sensor.phoniebox_test_box_gpio")
     assert version_sensor_state is not None
     assert version_sensor_state.state == STATE_OFF

--- a/test/test_sensor.py
+++ b/test/test_sensor.py
@@ -25,12 +25,12 @@ async def test_sensor_registry(
     assert len(er_items_after) == len(er_items_before) + 1  # now added the sensor
 
     entry: RegistryEntry = entity_registry.async_get(
-        "sensor.phoniebox_test_box_version_2"
+        "sensor.phoniebox_test_box_version"
     )
     assert entry
     assert entry.unique_id == "test_box-sensor.phoniebox_test_box_version"
 
-    version_sensor_state = hass.states.get("sensor.phoniebox_test_box_version_2")
+    version_sensor_state = hass.states.get("sensor.phoniebox_test_box_version")
     assert version_sensor_state is not None
     assert version_sensor_state.state == MOCK_VERSION
 
@@ -53,11 +53,11 @@ async def test_sensor_registry_ignore_value(
     assert len(er_items_after) == len(er_items_before)  # now added the sensor
 
     entry: RegistryEntry = entity_registry.async_get(
-        "sensor.phoniebox_test_box_volume_2"
+        "sensor.phoniebox_test_box_volume"
     )
     assert entry is None
 
-    version_sensor_state = hass.states.get("sensor.phoniebox_test_box_volume_2")
+    version_sensor_state = hass.states.get("sensor.phoniebox_test_box_volume")
     assert version_sensor_state is None
 
 
@@ -70,7 +70,7 @@ async def test_sensor_registry_update(
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/version", "2.3")
     await hass.async_block_till_done()
 
-    version_sensor_state = hass.states.get("sensor.phoniebox_test_box_version_2")
+    version_sensor_state = hass.states.get("sensor.phoniebox_test_box_version")
     assert version_sensor_state is not None
     assert version_sensor_state.state != MOCK_VERSION
     assert version_sensor_state.state == "2.3"
@@ -82,7 +82,7 @@ async def test_temperature_sensor(
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/temperature", "55.2'C")
     await hass.async_block_till_done()
 
-    sensor_state = hass.states.get("sensor.phoniebox_test_box_temperature_2")
+    sensor_state = hass.states.get("sensor.phoniebox_test_box_temperature")
     assert sensor_state is not None
     assert sensor_state.state == "55.2"
     assert sensor_state.attributes.get("unit_of_measurement") == TEMP_CELSIUS
@@ -92,7 +92,7 @@ async def test_gb_sensor(hass, mqtt_client_mock, mqtt_mock, mock_phoniebox, conf
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/disk_avail", "5")
     await hass.async_block_till_done()
 
-    sensor_state = hass.states.get("sensor.phoniebox_test_box_disk_avail_2")
+    sensor_state = hass.states.get("sensor.phoniebox_test_box_disk_avail")
     assert sensor_state is not None
     assert sensor_state.state == "5"
     assert sensor_state.attributes.get("unit_of_measurement") == DATA_GIGABYTES
@@ -104,7 +104,7 @@ async def test_player_state_sensor(
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/state", "play")
     await hass.async_block_till_done()
 
-    sensor_state = hass.states.get("sensor.phoniebox_test_box_player_state_2")
+    sensor_state = hass.states.get("sensor.phoniebox_test_box_player_state")
     assert sensor_state is not None
     assert sensor_state.state == "play"
 
@@ -113,7 +113,7 @@ async def test_state_sensor(hass, mqtt_client_mock, mqtt_mock, mock_phoniebox, c
     async_fire_mqtt_message(hass, "test_phoniebox/state", "online")
     await hass.async_block_till_done()
 
-    sensor_state = hass.states.get("sensor.phoniebox_test_box_state_2")
+    sensor_state = hass.states.get("sensor.phoniebox_test_box_state")
     assert sensor_state is not None
     assert sensor_state.state == "online"
 
@@ -126,7 +126,7 @@ async def test_spotify_source_sensor(
     )
     await hass.async_block_till_done()
 
-    sensor_state = hass.states.get("sensor.phoniebox_test_box_source_2")
+    sensor_state = hass.states.get("sensor.phoniebox_test_box_source")
     assert sensor_state is not None
     assert sensor_state.state == "spotify"
 
@@ -139,6 +139,6 @@ async def test_file_source_sensor(
     )
     await hass.async_block_till_done()
 
-    sensor_state = hass.states.get("sensor.phoniebox_test_box_source_2")
+    sensor_state = hass.states.get("sensor.phoniebox_test_box_source")
     assert sensor_state is not None
     assert sensor_state.state == "file"

--- a/test/test_switch.py
+++ b/test/test_switch.py
@@ -34,11 +34,11 @@ async def test_switch_registry(
         len(er_items_after) == len(er_items_before) + 2
     )  # now added the sensor and for binary most-likely a switch as well
 
-    entry: RegistryEntry = entity_registry.async_get("switch.phoniebox_test_box_gpio_2")
+    entry: RegistryEntry = entity_registry.async_get("switch.phoniebox_test_box_gpio")
     assert entry
     assert entry.unique_id == "test_box-switch.phoniebox_test_box_gpio"
 
-    switch_state = hass.states.get("switch.phoniebox_test_box_gpio_2")
+    switch_state = hass.states.get("switch.phoniebox_test_box_gpio")
     assert switch_state is not None
     assert switch_state.state == STATE_ON
 
@@ -52,7 +52,7 @@ async def test_switch_registry_update(
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/gpio", "false")
     await hass.async_block_till_done()
 
-    switch_state = hass.states.get("switch.phoniebox_test_box_gpio_2")
+    switch_state = hass.states.get("switch.phoniebox_test_box_gpio")
     assert switch_state is not None
     assert switch_state.state == STATE_OFF
 
@@ -62,7 +62,7 @@ async def test_switch_off(hass, mqtt_client_mock, mqtt_mock, mock_phoniebox, con
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/gpio", "true")
     await hass.async_block_till_done()
 
-    switch_state: State = hass.states.get("switch.phoniebox_test_box_gpio_2")
+    switch_state: State = hass.states.get("switch.phoniebox_test_box_gpio")
     assert switch_state is not None
     assert switch_state.state == STATE_ON
 
@@ -80,7 +80,7 @@ async def test_switch_on(hass, mqtt_client_mock, mqtt_mock, mock_phoniebox, conf
     async_fire_mqtt_message(hass, "test_phoniebox/attribute/gpio", "false")
     await hass.async_block_till_done()
 
-    switch_state: State = hass.states.get("switch.phoniebox_test_box_gpio_2")
+    switch_state: State = hass.states.get("switch.phoniebox_test_box_gpio")
     assert switch_state is not None
     assert switch_state.state == STATE_OFF
 


### PR DESCRIPTION
Most sensors entity id was ending with _2 this will fix the duplicate ids and remove the underscore_2

<img width="268" alt="image" src="https://user-images.githubusercontent.com/6809130/162179684-81af1d75-c41d-47d3-a7a7-46d2d9e9be9b.png">
