### PR TITLE
fix: hass.config_entries.async_forward_entry_setup has been removed

### DIFF
--- a/custom_components/phoniebox/__init__.py
+++ b/custom_components/phoniebox/__init__.py
@@ -34,9 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            await hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-            )
+            await hass.config_entries.async_forward_entry_setups(entry, coordinator.platforms)
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True


### PR DESCRIPTION
This fixes #114 

As mentioned in https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/, the object hass.config_entries.async_forward_entry_setup  has been removed in Home Assistant 2025.6. Instead hass.config_entries.async_forward_entry_setups is to be called from now on.

I implemented the fix mentioned in https://github.com/c0un7-z3r0/hass-phoniebox/issues/114#issuecomment-3094794253 by @lewis198804-byte